### PR TITLE
S25 Ultra Lens Profils Gyroflow

### DIFF
--- a/S25Ultra_14mm(0-2)_3840x2160.json
+++ b/S25Ultra_14mm(0-2)_3840x2160.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_16by9_3840x2160-49.93fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 49.927715,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.18494899823608008,
+    "camera_matrix": [
+      [
+        1633.2872011423426,
+        0.0,
+        1905.9111986801784
+      ],
+      [
+        0.0,
+        1634.0038831956738,
+        1064.3686850790402
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.36707381293118296,
+      0.06832182458149626,
+      0.1772609086928456,
+      -0.0512437681671289
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(0-2)_3840x2176.json
+++ b/S25Ultra_14mm(0-2)_3840x2176.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_16by9_3840x2176-49.93fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 49.927715,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.1906364619907713,
+    "camera_matrix": [
+      [
+        1633.082378296987,
+        0.0,
+        1905.800020158756
+      ],
+      [
+        0.0,
+        1633.7728520998967,
+        1072.44575548033
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.3636048791410105,
+      0.08982630323791135,
+      0.11846651370248638,
+      -0.003785889060211583
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(0-2)_4080x3060.json
+++ b/S25Ultra_14mm(0-2)_4080x3060.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3060-60.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 9,
+  "fps": 60.018394,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.23622267322020304,
+    "camera_matrix": [
+      [
+        1629.5606190344295,
+        0.0,
+        2026.129644172349
+      ],
+      [
+        0.0,
+        1628.7467899376134,
+        1519.8117871270767
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.36955495280674333,
+      0.019638266996679955,
+      0.37789577611383784,
+      -0.22514959426094716
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(0-2)_4080x3064.json
+++ b/S25Ultra_14mm(0-2)_4080x3064.json
@@ -1,0 +1,70 @@
+{
+  "name": "Samsung_S25 Ultra_14mm (0-2)_Reprojection: 0,43115_C4k_4by3_4080x3064-50.01fps",
+  "note": "Reprojection: 0,43115",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "Samsung",
+  "camera_model": "S25 Ultra",
+  "lens_model": "14mm (0-2)",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 9,
+  "fps": 50.007812,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.43114617963160345,
+    "camera_matrix": [
+      [
+        1622.9056111911798,
+        0.0,
+        2034.348464733601
+      ],
+      [
+        0.0,
+        1623.116449456691,
+        1511.8507797886798
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.37490023483222557,
+      0.010427338647017706,
+      0.2952881933517694,
+      -0.14448687655423567
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(0-2)_4096x3064.json
+++ b/S25Ultra_14mm(0-2)_4096x3064.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3064-60.03fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 8,
+  "fps": 60.030617,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.22117578794305345,
+    "camera_matrix": [
+      [
+        1627.908292139339,
+        0.0,
+        2031.2184489241013
+      ],
+      [
+        0.0,
+        1627.9859536747067,
+        1516.4782099603226
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.367642679233034,
+      0.03559605929601576,
+      0.30380888534290373,
+      -0.15096835526785674
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(2)_3840x2160.json
+++ b/S25Ultra_14mm(2)_3840x2160.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_16by9_3840x2160-60.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 8,
+  "fps": 60.019512,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.19518362252055863,
+    "camera_matrix": [
+      [
+        1554.8222268904526,
+        0.0,
+        1899.769791492892
+      ],
+      [
+        0.0,
+        1554.401980627116,
+        1062.4358946469108
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.3979966533327339,
+      -0.0767673666298525,
+      0.4638346946013731,
+      -0.24054998758835236
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(2)_3840x2176.json
+++ b/S25Ultra_14mm(2)_3840x2176.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_16by9_3840x2176-60.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 9,
+  "fps": 60.019512,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.2395595897403194,
+    "camera_matrix": [
+      [
+        1624.5839477365112,
+        0.0,
+        1907.386131634638
+      ],
+      [
+        0.0,
+        1624.695283592525,
+        1072.112240220917
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.39679753367823845,
+      -0.08486879475202357,
+      0.5107294596312716,
+      -0.2902376058728905
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(2)_4080x3060.json
+++ b/S25Ultra_14mm(2)_4080x3060.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3060-30.01fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "frame_readout_time": 14.499529324563524,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 7,
+  "fps": 30.012012,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.83736970789186,
+    "camera_matrix": [
+      [
+        1622.9173769169872,
+        0.0,
+        2032.8219905212422
+      ],
+      [
+        0.0,
+        1622.5158743472614,
+        1520.1734323846988
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.3780920508598306,
+      -0.01378337693545958,
+      0.36305706709184976,
+      -0.1995624420993775
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-18",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(2)_4080x3064.json
+++ b/S25Ultra_14mm(2)_4080x3064.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3064-60.03fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 60.025822,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.22583218286764004,
+    "camera_matrix": [
+      [
+        1616.874796464193,
+        0.0,
+        2026.6653345951986
+      ],
+      [
+        0.0,
+        1617.5630612036016,
+        1515.5196547824241
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.382189007327854,
+      -0.051026420115580146,
+      0.4452310033028404,
+      -0.24984521519491207
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_14mm(2)_4096x3072.json
+++ b/S25Ultra_14mm(2)_4096x3072.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4096x3072-60.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "orig_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "output_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 11,
+  "fps": 60.019505,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.2731914364754671,
+    "camera_matrix": [
+      [
+        1623.0769307761977,
+        0.0,
+        2039.314965941809
+      ],
+      [
+        0.0,
+        1623.847166046177,
+        1520.1601852141212
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.3780265235910374,
+      -0.008319823199210657,
+      0.3413668684571642,
+      -0.17893728654788513
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_23mm_3840x2160.json
+++ b/S25Ultra_23mm_3840x2160.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_16by9_3840x2160-30.00fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 30.0012,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.3203679792293519,
+    "camera_matrix": [
+      [
+        2655.1625188148205,
+        0.0,
+        1903.682858276112
+      ],
+      [
+        0.0,
+        2657.9814990173977,
+        1088.6900406765906
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.5962166424613932,
+      -1.3758631676810498,
+      4.767486126397055,
+      -5.410030783085589
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-18",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_23mm_3840x2176.json
+++ b/S25Ultra_23mm_3840x2176.json
@@ -1,0 +1,70 @@
+{
+  "name": "Samsung_S25 Ultra_23mm_3840x2160_4k_16by9_3840x2176-50.01fps",
+  "note": "Erreur de reprojection: 0,36546 Netteté moyenne de la mire: 3,18 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "Samsung",
+  "camera_model": "S25 Ultra",
+  "lens_model": "23mm",
+  "camera_setting": "3840x2160",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 50.014763,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.3654585699736859,
+    "camera_matrix": [
+      [
+        2673.7565971668323,
+        0.0,
+        1906.6368326432125
+      ],
+      [
+        0.0,
+        2675.6311307430137,
+        1102.185094479155
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.5780805129112,
+      -1.190587397275088,
+      3.867219655632807,
+      -4.052892675140983
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_23mm_4080x3060.json
+++ b/S25Ultra_23mm_4080x3060.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3060-59.43fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 59.426357,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.4603829952620938,
+    "camera_matrix": [
+      [
+        2672.6564439325007,
+        0.0,
+        2027.130881167189
+      ],
+      [
+        0.0,
+        2673.0796860840237,
+        1547.3748014260539
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.5593288057020439,
+      -0.8819076965391888,
+      2.5364936480704676,
+      -2.2540315730588047
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-15",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_23mm_4080x3064.json
+++ b/S25Ultra_23mm_4080x3064.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3064-46.95fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 46.94614,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.44737779019927615,
+    "camera_matrix": [
+      [
+        2667.5477629067013,
+        0.0,
+        2026.0473456784232
+      ],
+      [
+        0.0,
+        2667.3151460213935,
+        1549.4638915488847
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.5550066476345309,
+      -0.896245981852278,
+      2.6144973581499054,
+      -2.3430979227432904
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-16",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_23mm_4096x3072.json
+++ b/S25Ultra_23mm_4096x3072.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4096x3072-59.75fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "orig_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "output_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 59.752563,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.4520188115700075,
+    "camera_matrix": [
+      [
+        2664.786324382149,
+        0.0,
+        2033.8558347498472
+      ],
+      [
+        0.0,
+        2665.861230272553,
+        1541.4844599218106
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.563768494759953,
+      -0.8934925033402003,
+      2.573897608912428,
+      -2.319333112771144
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-16",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_63mm_3840x2160.json
+++ b/S25Ultra_63mm_3840x2160.json
@@ -1,0 +1,70 @@
+{
+  "name": "__63mm_Reprojection: 0,62730 Netteté: 2,11 px_4k_16by9_3840x2160-49.95fps",
+  "note": "Reprojection: 0,62730 Netteté: 2,11 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "63mm",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 9,
+  "fps": 49.951225,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.6273037286220903,
+    "camera_matrix": [
+      [
+        7174.455447542694,
+        0.0,
+        1913.0317072276505
+      ],
+      [
+        0.0,
+        7169.437312926656,
+        1059.0058614536015
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      -1.3280496602398622,
+      59.31214567988054,
+      -862.9304953835236,
+      4451.882147496075
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_63mm_3840x2176.json
+++ b/S25Ultra_63mm_3840x2176.json
@@ -1,0 +1,70 @@
+{
+  "name": "___Projection: 0,56298 Netteté: 2,15 px_4k_16by9_3840x2176-49.95fps",
+  "note": "Projection: 0,56298 Netteté: 2,15 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 9,
+  "fps": 49.951225,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.5629813763525868,
+    "camera_matrix": [
+      [
+        7166.357010033115,
+        0.0,
+        1918.137949680772
+      ],
+      [
+        0.0,
+        7158.428980005267,
+        1045.4947329859003
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      -1.2981470571073814,
+      56.746734886754695,
+      -804.4369188728273,
+      4022.2933364412233
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_63mm_4000x3000.json
+++ b/S25Ultra_63mm_4000x3000.json
@@ -1,0 +1,70 @@
+{
+  "name": "____4k_4by3_4000x3000-12.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4000,
+    "h": 3000
+  },
+  "orig_dimension": {
+    "w": 4000,
+    "h": 3000
+  },
+  "output_dimension": {
+    "w": 4000,
+    "h": 3000
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 12.021598,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.6847772632013183,
+    "camera_matrix": [
+      [
+        7134.454595577034,
+        0.0,
+        1998.6522325803048
+      ],
+      [
+        0.0,
+        7135.362419315994,
+        1460.417028972486
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      -1.1631295864125373,
+      50.00145031077709,
+      -679.3079771372205,
+      3262.281044654245
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-21",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Ultra_63mm_4032x3008.json
+++ b/S25Ultra_63mm_4032x3008.json
@@ -1,0 +1,70 @@
+{
+  "name": "___Projection: 0,60820 Netteté: 3,22 px_C4k_4by3_4032x3008-47.95fps",
+  "note": "Projection: 0,60820 Netteté: 3,22 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4032,
+    "h": 3008
+  },
+  "orig_dimension": {
+    "w": 4032,
+    "h": 3008
+  },
+  "output_dimension": {
+    "w": 4032,
+    "h": 3008
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 47.948517,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.6082023444063087,
+    "camera_matrix": [
+      [
+        7105.510364780008,
+        0.0,
+        2026.537920349239
+      ],
+      [
+        0.0,
+        7105.5636113482415,
+        1459.6529098955446
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      -1.1609460649852943,
+      49.53135211952419,
+      -662.1035820684832,
+      3108.5783234264877
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Utra_117mm_3840x2160.json
+++ b/S25Utra_117mm_3840x2160.json
@@ -1,0 +1,70 @@
+{
+  "name": "___3840x2160_4k_16by9_3840x2160-50.00fps",
+  "note": "Reprojection: 0,38990 Netteté: 4,58",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "3840x2160",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 49.999573,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.3899003362726301,
+    "camera_matrix": [
+      [
+        13517.064019514992,
+        0.0,
+        1859.8096611643168
+      ],
+      [
+        0.0,
+        13510.79117794373,
+        1232.751652992415
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.6722404641748385,
+      -0.6679762159206488,
+      -26.353993874180514,
+      -548.8750717735691
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Utra_117mm_3840x2176.json
+++ b/S25Utra_117mm_3840x2176.json
@@ -1,0 +1,70 @@
+{
+  "name": "___Reprojection: 0,37691 Netteté: 4,49 px_4k_16by9_3840x2176-50.00fps",
+  "note": "Reprojection: 0,37691 Netteté: 4,49 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "orig_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2176
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 49.999573,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.37691104904587747,
+    "camera_matrix": [
+      [
+        13519.15814389653,
+        0.0,
+        1884.6323433258576
+      ],
+      [
+        0.0,
+        13501.834870674635,
+        1223.4121467678115
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.74718367418268,
+      -16.093763694164277,
+      1084.018254753941,
+      -25755.00385640478
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Utra_117mm_4080x3060.json
+++ b/S25Utra_117mm_4080x3060.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4080x3060-30.01fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3060
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 13,
+  "fps": 30.007212,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.5067924085599633,
+    "camera_matrix": [
+      [
+        13400.289508987504,
+        0.0,
+        2028.1415244432928
+      ],
+      [
+        0.0,
+        13406.710364210796,
+        1664.5018020017444
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.5483213128629152,
+      16.68276660624998,
+      -1093.4460240827732,
+      21981.52267062779
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-18",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Utra_117mm_4080x3064.json
+++ b/S25Utra_117mm_4080x3064.json
@@ -1,0 +1,70 @@
+{
+  "name": "Samsung_S25 Ultra_117mm_3840x2160_C4k_4by3_4080x3064-50.02fps",
+  "note": "Erreur de repojection: 0,64666 Netteté moyenne de la mire: 14,25 px",
+  "calibrated_by": "Arnaud Fonteix",
+  "camera_brand": "Samsung",
+  "camera_model": "S25 Ultra",
+  "lens_model": "117mm",
+  "camera_setting": "3840x2160",
+  "calib_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "orig_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "output_dimension": {
+    "w": 4080,
+    "h": 3064
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 10,
+  "fps": 50.015076,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.6466584059872662,
+    "camera_matrix": [
+      [
+        13533.872437107393,
+        0.0,
+        2031.1897098268937
+      ],
+      [
+        0.0,
+        13537.55205169884,
+        1642.2821166178135
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.6972165792307332,
+      -6.234367796458263,
+      232.0332155682986,
+      -4088.763377030607
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-22",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/S25Utra_117mm_4096x3072.json
+++ b/S25Utra_117mm_4096x3072.json
@@ -1,0 +1,70 @@
+{
+  "name": "____C4k_4by3_4096x3072-60.02fps",
+  "note": "",
+  "calibrated_by": "Arnaud",
+  "camera_brand": "",
+  "camera_model": "",
+  "lens_model": "",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "orig_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "output_dimension": {
+    "w": 4096,
+    "h": 3072
+  },
+  "frame_readout_time": 14.5,
+  "frame_readout_direction": "TopToBottom",
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 60.016972,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.6803719216432358,
+    "camera_matrix": [
+      [
+        13446.666923437306,
+        0.0,
+        2050.2405280836615
+      ],
+      [
+        0.0,
+        13442.805461108539,
+        1698.5728581656876
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.6856141154744411,
+      -7.590121756972563,
+      351.3736397733703,
+      -5838.985740253249
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "",
+  "calibrator_version": "1.6.3",
+  "date": "2025-12-18",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": null,
+  "crop_factor": null,
+  "global_shutter": false
+}


### PR DESCRIPTION
Lens calibration profiles for all rear-facing cameras of the S25 Ultra, using full sensor readout and 4K UHD. Includes the non-standard resolutions generated by Motion Cam when “exact resolution” is disabled. Sensor readout time for all profiles: 14.5 ms. Tested and working.