### PR TITLE
Publish canonical lens database release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: profiles
-          path: profiles.cbor.gz
+          path: |
+            profiles.cbor.gz
+            canonical_lenses.json
 
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: profiles.cbor.gz
+          artifacts: profiles.cbor.gz,canonical_lenses.json
           tag: "v${{ github.run_number }}"

--- a/compress.rs
+++ b/compress.rs
@@ -18,7 +18,7 @@ fn main() {
     walkdir::WalkDir::new(&pwd).into_iter().for_each(|e| {
         if let Ok(entry) = e {
             let f_name = entry.path().to_string_lossy().replace('\\', "/");
-            if f_name.ends_with(".json") || f_name.ends_with(".gyroflow") {
+            if (f_name.ends_with(".json") || f_name.ends_with(".gyroflow")) && !f_name.ends_with("canonical_lenses.json") {
                 if let Ok(data) = std::fs::read_to_string(&f_name) {
                     let parsed = serde_json::from_str::<serde_json::Value>(&data).unwrap();
                     let pos = f_name.find(&pwd).unwrap();


### PR DESCRIPTION
## Scope

This companion PR supports gyroflow/gyroflow#742 by publishing the canonical camera/lens database as a release asset next to `profiles.cbor.gz`.

## What changed

- Added `canonical_lenses.json` at the repository root.
  - Current generated contents: version 37, 258 brands, 52 mounts, 2,638 cameras, 7,111 lenses, and 6,517 observed setup rows.
  - Sources recorded in the file:
    - `gyroflow/lens_profiles` commit `bf0976d039d27a64b54517adfa941443865a492e`
    - `lensfun/lensfun` commit `01e64b74507d9b818478f0e02f338fada8dd5680`
- Updated `compress.rs` so `canonical_lenses.json` is not packed into `profiles.cbor.gz` as a legacy lens profile.
- Updated `.github/workflows/release.yml` so releases include both:
  - `profiles.cbor.gz`
  - `canonical_lenses.json`

## Why

The app-side gyroflow/gyroflow change downloads `canonical_lenses.json` through the existing lens profile update path. Keeping this file as a separate release asset avoids changing the existing profile bundle format while giving the app a canonical identity/index database for later selector and compatibility work.

## Validation

- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
  - Passes in `gyroflow/lens_profiles`.
- The same `canonical_lenses.json` is present in both repos:
  - `gyroflow/resources/camera_presets/canonical_lenses.json`
  - `lens_profiles/canonical_lenses.json`
