### PR TITLE
Add Sony ILCE-7M5 lens profiles (Viltrox 16mm, Sigma 28-105mm, DZOFilm Arcana 32mm)

### DIFF
--- a/Sony/Sony_ILCE-7M5_DZOFilm Arcana Anamorphic 32mm_32mm_1080p_8by3_2880x1080-29.97fps.json
+++ b/Sony/Sony_ILCE-7M5_DZOFilm Arcana Anamorphic 32mm_32mm_1080p_8by3_2880x1080-29.97fps.json
@@ -1,0 +1,70 @@
+{
+  "name": "Sony ILCE-7M5 | DZOFilm Arcana 32mm T2.1 Anamorphic | 32mm,1080p,29.97fps",
+  "note": "Works with any resolution and framerate given no crop",
+  "calibrated_by": "Máté Forgács",
+  "camera_brand": "Sony",
+  "camera_model": "ILCE-7M5",
+  "lens_model": "DZOFilm Arcana Anamorphic 32mm",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 2880,
+    "h": 1080
+  },
+  "orig_dimension": {
+    "w": 2880,
+    "h": 1080
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 1440
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.5,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 29.97003,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 1.2497741524973458,
+    "camera_matrix": [
+      [
+        1772.9785940083168,
+        0.0,
+        1434.163927593702
+      ],
+      [
+        0.0,
+        1768.4285956642066,
+        537.0452741109539
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      -0.035644332176973735,
+      0.1003030731754943,
+      -0.20308100896670012,
+      0.13430919918646686
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "sony-ilce-7m5-dzofilmarcanaanamorphic32mm-32.00mm-2880x1080@29970",
+  "calibrator_version": "1.6.3",
+  "date": "2026-06-28",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": 32.0,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/Sony/Sony_ILCE-7M5_Sigma 28-105mm F2.8 DG DN Art_28mm_1080p_16by9_1920x1080-29.97fps.json
+++ b/Sony/Sony_ILCE-7M5_Sigma 28-105mm F2.8 DG DN Art_28mm_1080p_16by9_1920x1080-29.97fps.json
@@ -1,0 +1,70 @@
+{
+  "name": "Sony ILCE-7M5 | Sigma 28-105mm F2.8 DG DN Art | 28mm,1080p,29.97fps",
+  "note": "Works with any resolution and framerate given no crop",
+  "calibrated_by": "Máté Forgács",
+  "camera_brand": "Sony",
+  "camera_model": "ILCE-7M5",
+  "lens_model": "Sigma 28-105mm F2.8 DG DN Art",
+  "camera_setting": "28mm",
+  "calib_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "orig_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 29.97003,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.1711972011149403,
+    "camera_matrix": [
+      [
+        1501.4555847990516,
+        0.0,
+        964.3292901821169
+      ],
+      [
+        0.0,
+        1500.9095298428747,
+        538.5593203161369
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.1167514596580497,
+      0.2768480437872083,
+      -0.7166909352468006,
+      1.43703635060362
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "sony-ilce-7m5-sigma28-105mmf2.8dgdnart-28.00mm-1920x1080@29970",
+  "calibrator_version": "1.6.3",
+  "date": "2026-06-28",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": 28.0,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/Sony/Sony_ILCE-7M5_Sigma 28-105mm F2.8 DG DN Art_50mm_1080p_16by9_1920x1080-29.97fps.json
+++ b/Sony/Sony_ILCE-7M5_Sigma 28-105mm F2.8 DG DN Art_50mm_1080p_16by9_1920x1080-29.97fps.json
@@ -1,0 +1,70 @@
+{
+    "name": "Sony ILCE-7M5 | Sigma 28-105mm F2.8 DG DN Art | 50mm,1080p,29.97fps",
+    "note": "Works with any resolution and framerate given no crop",
+  "calibrated_by": "Máté Forgács",
+  "camera_brand": "Sony",
+  "camera_model": "ILCE-7M5",
+  "lens_model": "Sigma 28-105mm F2.8 DG DN Art",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "orig_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "output_dimension": {
+    "w": 3840,
+    "h": 2160
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 29.97003,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.2346433962192692,
+    "camera_matrix": [
+      [
+        2608.586591573147,
+        0.0,
+        965.2211560301907
+      ],
+      [
+        0.0,
+        2608.398518185053,
+        541.0083479480542
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.35815536221121136,
+      0.8871835183514309,
+      -1.750561826838175,
+      12.801857419357615
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "sony-ilce-7m5-sigma28-105mmf2.8dgdnart-50.00mm-1920x1080@29970",
+  "calibrator_version": "1.6.3",
+  "date": "2026-06-28",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": 50.0,
+  "crop_factor": null,
+  "global_shutter": false
+}

--- a/Sony/Sony_ILCE-7M5_Viltrox 16mm F1.8 FE_16mm_1080p_16by9_1920x1080-29.97fps.json
+++ b/Sony/Sony_ILCE-7M5_Viltrox 16mm F1.8 FE_16mm_1080p_16by9_1920x1080-29.97fps.json
@@ -1,0 +1,70 @@
+{
+  "name": "Sony ILCE-7M5 | Viltrox 16mm F1.8 FE | 16mm,1080p,29.97fps",
+  "note": "Works with any resolution and framerate given no crop",
+  "calibrated_by": "Máté Forgács",
+  "camera_brand": "Sony",
+  "camera_model": "ILCE-7M5",
+  "lens_model": "Viltrox 16mm F1.8 FE",
+  "camera_setting": "",
+  "calib_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "orig_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "output_dimension": {
+    "w": 1920,
+    "h": 1080
+  },
+  "frame_readout_time": null,
+  "frame_readout_direction": null,
+  "gyro_lpf": null,
+  "input_horizontal_stretch": 1.0,
+  "input_vertical_stretch": 1.0,
+  "num_images": 15,
+  "fps": 29.97003,
+  "crop": null,
+  "official": false,
+  "asymmetrical": false,
+  "fisheye_params": {
+    "RMS_error": 0.1924452187481699,
+    "camera_matrix": [
+      [
+        883.3333511265473,
+        0.0,
+        963.9379884726093
+      ],
+      [
+        0.0,
+        883.311228216995,
+        533.6317272743278
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ],
+    "distortion_coeffs": [
+      0.3559643647235299,
+      0.07075204096810175,
+      0.08473053023897206,
+      0.00674965904509858
+    ],
+    "radial_distortion_limit": null
+  },
+  "identifier": "sony-ilce-7m5-viltrox16mmf1.8fe-16.00mm-1920x1080@29970",
+  "calibrator_version": "1.6.3",
+  "date": "2026-06-28",
+  "compatible_settings": [],
+  "sync_settings": null,
+  "distortion_model": null,
+  "digital_lens": null,
+  "digital_lens_params": null,
+  "interpolations": null,
+  "focal_length": 16.0,
+  "crop_factor": null,
+  "global_shutter": false
+}


### PR DESCRIPTION
Four lens profiles for the **Sony ILCE-7M5**, calibrated and tested with **Gyroflow 1.6.3** by Máté Forgács. Added under `Sony/`.

| Lens | Focal | Calib resolution | RMS error |
|------|-------|------------------|-----------|
| Viltrox 16mm F1.8 FE | 16 mm | 1920×1080 | 0.19 |
| Sigma 28-105mm F2.8 DG DN Art | 28 mm | 1920×1080 | 0.17 |
| Sigma 28-105mm F2.8 DG DN Art | 50 mm | 1920×1080 | 0.23 |
| DZOFilm Arcana 32mm T2.1 Anamorphic (1.5×) | 32 mm | 2880×1080 | 1.25 |

Identifiers use the standard auto-generated format (e.g. `sony-ilce-7m5-viltrox16mmf1.8fe-16.00mm-1920x1080@29970`). Contributed under the repo's CC0 license.
